### PR TITLE
Add CODEOWNERS requiring @armin976 approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Everything requires review from @armin976
+*       @armin976


### PR DESCRIPTION
Adds .github/CODEOWNERS so all changes require approval from @armin976. Branch protection is enabled to require PRs and CODEOWNER review, force-push and deletion disabled, admins included.